### PR TITLE
Update ReactiveSwift dependency to last version

### DIFF
--- a/Moya-Gloss.podspec
+++ b/Moya-Gloss.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
     ss.source_files = "Source/ReactiveCocoa/*.swift"
     ss.dependency "Moya-Gloss/Core"
     ss.dependency "Moya/ReactiveCocoa"
-    ss.dependency 'ReactiveSwift', '1.0.0-alpha.1'
+    ss.dependency 'ReactiveSwift', '1.0.0-alpha.3'
   end
 
 end


### PR DESCRIPTION
Without this change cocoapods throws an error if you're also using ReactiveCocoa on cocoapods swift3 version.
