### PR TITLE
Missing namespace for Decodable

### DIFF
--- a/Source/ReactiveSwift/SignalProducer+Gloss.swift
+++ b/Source/ReactiveSwift/SignalProducer+Gloss.swift
@@ -38,7 +38,7 @@ public extension SignalProducerProtocol where Value == Moya.Response, Error == M
   
   /// Maps nested data received from the signal into an array of a type that implements the Decodable protocol.
   /// The signal errors on conversion failure.
-  public func mapArray<T: Decodable>(type: T.Type, forKeyPath keyPath: String) -> SignalProducer<[T], Error> {
+  public func mapArray<T: Gloss.Decodable>(type: T.Type, forKeyPath keyPath: String) -> SignalProducer<[T], Error> {
     return producer.flatMap(.latest) { response -> SignalProducer<[T], Error> in
       return unwrapThrowable { try response.mapArray(T.self, forKeyPath: keyPath) }
     }


### PR DESCRIPTION
Looks like there was one more un-namespaced mention of Decodable, which (under Xcode 9 Beta 6) was causing an "error: 'Decodable' is ambiguous for type lookup in this context" compilation error. This seems to fix that problem...